### PR TITLE
Small comment fix

### DIFF
--- a/contracts/ERC20Permit.sol
+++ b/contracts/ERC20Permit.sol
@@ -66,7 +66,7 @@ abstract contract ERC20Permit is ERC20, IERC2612Permit {
             // Load free memory pointer
             let memPtr := mload(64)
 
-            // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")
+            // keccak256("Permit(address owner,address spender,uint256 amount,uint256 nonce,uint256 deadline)")
             mstore(memPtr, 0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9)
             mstore(add(memPtr, 32), owner)
             mstore(add(memPtr, 64), spender)


### PR DESCRIPTION
The word "value" is used in the comment, but "amount" is used in the code below.